### PR TITLE
Allows to quit on `WM_QUIT` message for Windows

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, ptr::null_mut};
 use std::mem;
 use winapi::shared::windef::HWND;
 use winapi::um::winuser;
@@ -13,23 +13,23 @@ pub mod modifiers {
 
 pub mod keys {
     use winapi::um::winuser;
-    pub const BACKSPACE: u32 = winuser::VK_BACK;
-    pub const TAB: u32 = winuser::VK_TAB;
-    pub const ENTER: u32 = winuser::VK_RETURN;
-    pub const CAPS_LOCK: u32 = winuser::VK_CAPITAL;
-    pub const ESCAPE: u32 = winuser::VK_ESCAPE;
-    pub const SPACEBAR: u32 = winuser::VK_SPACE;
-    pub const PAGE_UP: u32 = winuser::VK_PRIOR;
-    pub const PAGE_DOWN: u32 = winuser::VK_NEXT;
-    pub const END: u32 = winuser::VK_END;
-    pub const HOME: u32 = winuser::VK_HOME;
-    pub const ARROW_LEFT: u32 = winuser::VK_LEFT;
-    pub const ARROW_RIGHT: u32 = winuser::VK_RIGHT;
-    pub const ARROW_UP: u32 = winuser::VK_UP;
-    pub const ARROW_DOWN: u32 = winuser::VK_DOWN;
-    pub const PRINT_SCREEN: u32 = winuser::VK_SNAPSHOT;
-    pub const INSERT: u32 = winuser::VK_INSERT;
-    pub const DELETE: u32 = winuser::VK_DELETE;
+    pub const BACKSPACE: i32 = winuser::VK_BACK;
+    pub const TAB: i32 = winuser::VK_TAB;
+    pub const ENTER: i32 = winuser::VK_RETURN;
+    pub const CAPS_LOCK: i32 = winuser::VK_CAPITAL;
+    pub const ESCAPE: i32 = winuser::VK_ESCAPE;
+    pub const SPACEBAR: i32 = winuser::VK_SPACE;
+    pub const PAGE_UP: i32 = winuser::VK_PRIOR;
+    pub const PAGE_DOWN: i32 = winuser::VK_NEXT;
+    pub const END: i32 = winuser::VK_END;
+    pub const HOME: i32 = winuser::VK_HOME;
+    pub const ARROW_LEFT: i32 = winuser::VK_LEFT;
+    pub const ARROW_RIGHT: i32 = winuser::VK_RIGHT;
+    pub const ARROW_UP: i32 = winuser::VK_UP;
+    pub const ARROW_DOWN: i32 = winuser::VK_DOWN;
+    pub const PRINT_SCREEN: i32 = winuser::VK_SNAPSHOT;
+    pub const INSERT: i32 = winuser::VK_INSERT;
+    pub const DELETE: i32 = winuser::VK_DELETE;
 }
 
 pub type ListenerID = i32;
@@ -68,14 +68,16 @@ impl Listener {
 
     pub fn listen(self) {
         unsafe {
+            let mut msg = mem::MaybeUninit::uninit().assume_init();
             loop {
-                let mut msg = mem::MaybeUninit::uninit().assume_init();
-                while winuser::GetMessageW(&mut msg, 0 as HWND, 0, 0) > 0 {
-                    if msg.wParam != 0 {
+                match winuser::GetMessageW(&mut msg, null_mut(), 0, 0) {
+                    0 => break,
+                    ret if msg.wParam != 0 && ret != -1 => {
                         if let Some(handler) = self.handlers.get(&(msg.wParam as i32)) {
                             handler();
                         }
                     }
+                    _ => {}
                 }
             }
         }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -66,6 +66,19 @@ impl Listener {
         }
     }
 
+    /// Sends [`WM_QUIT`](winapi::um::winuser::WM_QUIT) siqnal to interupt [`listen`](#listen) infinite loop.
+    pub fn post_quit_message() {
+        unsafe { winuser::PostQuitMessage(0) }
+    }
+
+    /// Runs blocking infinite loop to listen for events.
+    ///
+    /// *Note:* callbacks are beeing called from current thread in "blocking" fashion. Make sure you aren't blocking
+    /// main thread for ever if you want to dispatch hotkey presses.
+    ///
+    /// You can execute [`PostQuitMessage`](winapi::um::winuser::PostQuitMessage) or call
+    /// [`Listener::post_quit_message`](#post_quit_message)
+    /// to interupt this loop.
     pub fn listen(self) {
         unsafe {
             let mut msg = mem::MaybeUninit::uninit().assume_init();


### PR DESCRIPTION
Pull requests consist of the following changes:

* constant's type changed from `u32` to `i32` to stay consistant with `winapi` constant's type
* `listen` method modified to interupt infinite loop when [`WM_QUIT`][wm-quit] message received
* added `post_quit_message` helper function that simply calls [`PostQuitMessage`][post-quit-message] that sends `WM_QUIT`
* added a bit of docs for `listen` and `post_quit_message`

From `PostQuitMessage` docs:
> Indicates to the system that a __thread__ has made a request to terminate (quit).

I have verified that posting `WM_QUIT` by calling `PostQuitMessage` message from different process have no effect on the `listen` loop.

[wm-quit]: https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-quit
[post-quit-message]: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-postquitmessage